### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/SproutLists.php
+++ b/src/SproutLists.php
@@ -106,7 +106,7 @@ class SproutLists extends Plugin
             $variable->set('sproutLists', SproutListsVariable::class);
         });
 
-        Craft::$app->view->twig->addExtension(new TwigExtensions());
+        Craft::$app->view->registerTwigExtension(new TwigExtensions());
 
         Event::on(Lists::class, Lists::EVENT_REGISTER_LIST_TYPES, function(Event $event) {
             $event->listTypes[] = SubscriberListType::class;


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.